### PR TITLE
Update parser.py

### DIFF
--- a/raster/tiles/parser.py
+++ b/raster/tiles/parser.py
@@ -51,7 +51,7 @@ class RasterLayerParser(object):
             parsestatus.tile_levels.sort()
 
         # Prepare datetime stamp for log
-        now = '[{0}] '.format(datetime.datetime.now().strftime('%Y-%m-%d %T'))
+        now = '[{0}] '.format(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
 
         if parsestatus.log:
             now = '\n' + now


### PR DESCRIPTION
%T is not a valid format on Windows and will throw an exception: `ValueError: Invalid format string`

To reproduce run on a Windows machine: `"[{0}] ".format(datetime.datetime.now().strftime('%Y-%m-%d %T'))`

It's better to use %H:%M:%S instead. See relevant discussion: http://stackoverflow.com/questions/26140502/python-invalid-format-string