### PR TITLE
Updated ArrayField default to fix Django warning

### DIFF
--- a/raster/models.py
+++ b/raster/models.py
@@ -300,7 +300,7 @@ class RasterLayerParseStatus(models.Model):
     rasterlayer = models.OneToOneField(RasterLayer, related_name='parsestatus', on_delete=models.CASCADE)
     status = models.IntegerField(choices=STATUS_CHOICES, default=UNPARSED)
     log = models.TextField(default='', editable=False)
-    tile_levels = ArrayField(models.PositiveIntegerField(), default=[])
+    tile_levels = ArrayField(models.PositiveIntegerField(), default=list)
 
     def __str__(self):
         return '{0} - {1}'.format(self.rasterlayer.name, self.get_status_display())


### PR DESCRIPTION
The defaults should be changed: from [] to list

https://docs.djangoproject.com/en/1.9/ref/contrib/postgres/fields/#django.contrib.postgres.fields.ArrayField

If you give the field a default, ensure it’s a callable such as list (for an empty default) or a callable that returns a list (such as a function). Incorrectly using default=[] creates a mutable default that is shared between all instances of ArrayField.