### PR TITLE
Added support for db_alias in migrations

### DIFF
--- a/raster/migrations/0005_auto_20141014_0955.py
+++ b/raster/migrations/0005_auto_20141014_0955.py
@@ -1,17 +1,22 @@
 # -*- coding: utf-8 -*-
 from django.db import migrations
 
+def forward(apps, schema_editor):
+    migrations.RunSQL(
+            "DROP INDEX IF EXISTS raster_rastertile_rast_st_convexhull_idx;\
+            CREATE INDEX raster_rastertile_rast_st_convexhull_idx ON raster_rastertile USING gist( ST_ConvexHull(rast) )"
+    )
+def reverse(apps, schema_editor):
+    migrations.RunSQL(
+            "DROP INDEX IF EXISTS raster_rastertile_rast_st_convexhull_idx"
+    )
 
 class Migration(migrations.Migration):
 
     dependencies = [
         ('raster', '0004_rasterlayermetadata'),
     ]
-
+    
     operations = [
-        migrations.RunSQL(
-            "DROP INDEX IF EXISTS raster_rastertile_rast_st_convexhull_idx; CREATE INDEX raster_rastertile_rast_st_convexhull_idx\
-             ON raster_rastertile USING gist( ST_ConvexHull(rast) )",
-            "DROP INDEX IF EXISTS raster_rastertile_rast_st_convexhull_idx"
-        )
+        migrations.RunPython(forward, reverse),
     ]

--- a/raster/migrations/0017_copy_srids_20150922_0207.py
+++ b/raster/migrations/0017_copy_srids_20150922_0207.py
@@ -9,7 +9,8 @@ def move_srid_from_layer_to_metadata_forward(apps, schema_editor):
     """
     RasterLayer = apps.get_model("raster", "RasterLayer")
     RasterLayerMetadata = apps.get_model("raster", "RasterLayerMetadata")
-    for lyr in RasterLayer.objects.all():
+    db_alias = schema_editor.connection.alias
+    for lyr in RasterLayer.objects.using(db_alias).all():
         meta, created = RasterLayerMetadata.objects.get_or_create(rasterlayer=lyr)
         meta.srid = lyr.srid
         meta.save()
@@ -20,7 +21,8 @@ def move_srid_from_layer_to_metadata_backward(apps, schema_editor):
     Copy the srids back to the raster layers.
     """
     RasterLayer = apps.get_model("raster", "RasterLayer")
-    for lyr in RasterLayer.objects.all():
+    db_alias = schema_editor.connection.alias
+    for lyr in RasterLayer.objects.using(db_alias).all():
         if hasattr(lyr, 'rasterlayermetadata'):
             lyr.srid = lyr.rasterlayermetadata.srid
             lyr.save()

--- a/raster/migrations/0022_auto_20151110_0810.py
+++ b/raster/migrations/0022_auto_20151110_0810.py
@@ -8,7 +8,8 @@ def move_parse_log_to_parse_status_objects_forward(apps, schema_editor):
     """
     RasterLayer = apps.get_model("raster", "RasterLayer")
     RasterLayerParseStatus = apps.get_model("raster", "RasterLayerParseStatus")
-    for lyr in RasterLayer.objects.all():
+    db_alias = schema_editor.connection.alias
+    for lyr in RasterLayer.objects.using(db_alias).all():
         status, created = RasterLayerParseStatus.objects.get_or_create(rasterlayer=lyr)
         status.log = lyr.parse_log
         if 'Successfully finished parsing raster' in lyr.parse_log:
@@ -23,7 +24,8 @@ def move_parse_log_to_parse_status_objects_backward(apps, schema_editor):
     Copy the srids back to the raster layers.
     """
     RasterLayer = apps.get_model("raster", "RasterLayer")
-    for lyr in RasterLayer.objects.all():
+    db_alias = schema_editor.connection.alias
+    for lyr in RasterLayer.objects.using(db_alias).all():
         if hasattr(lyr, 'parsestatus'):
             lyr.parse_log = lyr.parsestatus.log
             lyr.save()

--- a/raster/migrations/0034_legendentryorder.py
+++ b/raster/migrations/0034_legendentryorder.py
@@ -13,7 +13,8 @@ def move_legend_entries_to_through_model(apps, schema_editor):
     """
     Legend = apps.get_model("raster", "Legend")
     LegendEntryOrder = apps.get_model("raster", "LegendEntryOrder")
-    for leg in Legend.objects.all():
+    db_alias = schema_editor.connection.alias
+    for leg in Legend.objects.using(db_alias).all():
         for entry in leg.entries.all():
             # Respect unique contraint.
             if LegendEntryOrder.objects.filter(legend=leg, legendentry=entry).exists():
@@ -43,7 +44,8 @@ def move_legend_entries_from_through_model_to_normal_m2m(apps, schema_editor):
     """
     Legend = apps.get_model("raster", "Legend")
     LegendEntryOrder = apps.get_model("raster", "LegendEntryOrder")
-    for leg in Legend.objects.all():
+    db_alias = schema_editor.connection.alias
+    for leg in Legend.objects.using(db_alias).all():
         for enor in LegendEntryOrder.objects.filter(legend=leg):
             leg.entries.add(enor.legendentry)
 

--- a/raster/migrations/0036_auto_20170509_0548.py
+++ b/raster/migrations/0036_auto_20170509_0548.py
@@ -7,8 +7,9 @@ def set_legend_on_entry(apps, schema_editor):
     # Get models.
     Legend = apps.get_model("raster", "Legend")
     LegendEntryOrder = apps.get_model("raster", "LegendEntryOrder")
+    db_alias = schema_editor.connection.alias
     # Loop through legend and entries.
-    for legend in Legend.objects.all():
+    for legend in Legend.objects.using(db_alias).all():
         for entry in legend.entries.all():
             # Set legend direct foreign key.
             entry.legend = legend


### PR DESCRIPTION
<h1>Issue</h1>
Current migrations require that the django-raster library's tables are created at the "default" database connection in settings.py. This did not allow the library to work with multiple databases and database routers if django-raster's tables weren't being created in the "default" database connection. 

<h1>Solution</h1>
Modified migrations to allow django-raster to run migrations and create the tables in a different database connection. This allows the library to support the creation of tables in a different database such as when running "python manage.py migrate --database=db_name"

<h1>Migration Changes</h1>
Migration 0005: Changed the RunSQL function to RunPython so that migrations won't run into an error when the user enters "python manage.py migrate" when django-raster's tables are being created in a database that isn't in the "default" connection. 
<br><br>
Migrations 0017, 0022, 0034, 0036: Added "db_alias = schema_editor.connection.alias" to let the migration use the database connection specified by the user or the router. Changed "for x in ModelName.object.all()" to "for x in ModelName.objects.using(db_alias).all()" in the migration python functions to use the specified database connection. 
