### PR TITLE
Fixed ACTION_CHECKBOX_NAME reference in admin.py

### DIFF
--- a/raster/admin.py
+++ b/raster/admin.py
@@ -127,7 +127,7 @@ class RasterLayerModelAdmin(admin.ModelAdmin):
 
         # Before posting, prepare empty action form
         if not form:
-            form = FilenameActionForm(initial={'_selected_action': request.POST.getlist(admin.ACTION_CHECKBOX_NAME)})
+            form = FilenameActionForm(initial={'_selected_action': request.POST.getlist(admin.helpers.ACTION_CHECKBOX_NAME)})
 
         return render(request, 'raster/updatepath.html', {'items': queryset, 'form': form, 'title': u'Update Path'})
 


### PR DESCRIPTION
In Django release 3.1, the compatibility import `admin.ACTION_CHECKBOX_NAME` was removed. This was causing an error in admin.py whenever you try to manually edit the filepath for a layer from the admin page. The fix is just to change how `ACTION_CHECKBOX_NAME` is referenced.

Relevant Django update documentation: 
https://docs.djangoproject.com/en/3.2/releases/3.1/#id2